### PR TITLE
don't process symlinks

### DIFF
--- a/DarkBlood.sh
+++ b/DarkBlood.sh
@@ -2,7 +2,7 @@
 
 test "$(basename "$PWD")" == "DarkBlood" || exit 1
 
-find . -name '*.png' \
+find . -name '*.png' -type f \
   -execdir convert '{}' -channel rgba -separate -swap 0,1 -combine '{}.out' \;
 
 find . -name '*.png' \

--- a/DarkFire.sh
+++ b/DarkFire.sh
@@ -2,7 +2,7 @@
 
 test "$(basename "$PWD")" == "DarkFire" || exit 1
 
-find . -name '*.png' \
+find . -name '*.png' -type f \
   -execdir convert '{}' -channel rgba -separate -swap 0,2 -delete 1 -duplicate 1,1 -insert 1 -combine '{}.out' \;
 
 find . -name '*.png' \


### PR DESCRIPTION
There's a lot of duplicated files in the upstream sources of Dark{Cold,Mint}, the Debian packaging deduplicates them as symlinks.  Alas, as `convert`'s output is not stable with different filenames, deduplicating after the fact doesn't work.